### PR TITLE
Hide pcre2 in pimpl

### DIFF
--- a/encoding.cc
+++ b/encoding.cc
@@ -21,6 +21,9 @@
 
 #include <stdexcept>
 
+#define PCRE2_CODE_UNIT_WIDTH 0
+#include <pcre2.h>
+
 GptEncoding::GptEncoding(const std::string &pattern_string, const std::unordered_map<std::vector<uint8_t>, int, VectorHash> &byte_pair_ranks,
     const std::unordered_map<std::string, int> &special_token_mappings, int explicit_n_vocab) :
     max_token_value_(0),

--- a/encoding_utils.h
+++ b/encoding_utils.h
@@ -22,10 +22,6 @@
 #include <string>
 #include <vector>
 
-#define PCRE2_CODE_UNIT_WIDTH 0
-
-#include <pcre2.h>
-
 struct VectorHash {
     template<typename T>
     std::size_t operator()(const std::vector<T> &v) const

--- a/pcre2_regex.cc
+++ b/pcre2_regex.cc
@@ -17,7 +17,6 @@
  */
 #include "pcre2_regex.h"
 
-#include <memory>
 #include <stdexcept>
 
 #define PCRE2_CODE_UNIT_WIDTH 0

--- a/pcre2_regex.cc
+++ b/pcre2_regex.cc
@@ -16,10 +16,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "pcre2_regex.h"
+
+#include <memory>
 #include <stdexcept>
 
-PCRERegex::PCRERegex(const std::string &pattern, int flags)
-{
+#define PCRE2_CODE_UNIT_WIDTH 0
+#include <pcre2.h>
+
+class PCRERegex::Impl {
+public:
+    Impl(const std::string &pattern, int flags);
+    Impl(Impl&& other);
+    ~Impl();
+
+    std::vector<std::string> get_all_matches(const std::string &text) const;
+    std::vector<std::pair<std::string::size_type, std::string::size_type>> all_matches(const std::string &text) const;
+    bool contains(const std::string& text) const;
+    void replace_all(std::string &text, const std::string &replacement) const;
+
+private:
+    pcre2_code_8 *regex_ = nullptr;
+};
+
+PCRERegex::Impl::Impl(const std::string &pattern, int flags) {
     int error = 0;
     PCRE2_SIZE error_offset = 0;
     flags |= PCRE2_UCP | PCRE2_UTF;
@@ -32,22 +51,13 @@ PCRERegex::PCRERegex(const std::string &pattern, int flags)
     }
 }
 
-PCRERegex::PCRERegex(const std::string &pattern) :
-    PCRERegex(pattern, 0) { }
-
-PCRERegex::PCRERegex(PCRERegex && other):regex_(other.regex_)
-{
-    other.regex_ = nullptr;
-}
-
-PCRERegex::~PCRERegex()
-{
+PCRERegex::Impl::~Impl() {
     if (regex_) {
         pcre2_code_free_8(regex_);
     }
 }
 
-std::vector<std::string> PCRERegex::get_all_matches(const std::string &text) const
+std::vector<std::string> PCRERegex::Impl::get_all_matches(const std::string &text) const 
 {
     std::vector<std::string> matches;
     auto pairs = all_matches(text);
@@ -57,25 +67,8 @@ std::vector<std::string> PCRERegex::get_all_matches(const std::string &text) con
     return matches;
 }
 
-void PCRERegex::replace_all(std::string &text, const std::string &replacement) const
-{
-    std::string result;
-    std::string::size_type last = 0;
-    auto pairs = all_matches(text);
-    for(auto &x:pairs) {
-        result.append(text.substr(last, x.first - last));
-        last = x.first + x.second;
-        result.append(replacement);
-    }
-    result.append(text.substr(last));
-    text = result;
-}
-
-bool PCRERegex::contains(const std::string& text) const {
-    return !all_matches(text).empty();
-}
-
-std::vector<std::pair<std::string::size_type, std::string::size_type>> PCRERegex::all_matches(const std::string &text) const
+std::vector<std::pair<std::string::size_type, std::string::size_type>>
+PCRERegex::Impl::all_matches(const std::string &text) const 
 {
     std::vector<std::pair<std::string::size_type, std::string::size_type>> result;
     auto text_ptr = reinterpret_cast<PCRE2_SPTR8>(text.c_str());
@@ -95,4 +88,62 @@ std::vector<std::pair<std::string::size_type, std::string::size_type>> PCRERegex
     } while (rc >= 0 && start_offset < text_length && match_length > 0);
     pcre2_match_data_free_8(match_data);
     return result;
+}
+
+bool PCRERegex::Impl::contains(const std::string& text) const 
+{
+    return !all_matches(text).empty();
+}
+
+void PCRERegex::Impl::replace_all(std::string &text, const std::string &replacement) const 
+{
+    std::string result;
+    std::string::size_type last = 0;
+    auto pairs = all_matches(text);
+    for(auto &x:pairs) {
+        result.append(text.substr(last, x.first - last));
+        last = x.first + x.second;
+        result.append(replacement);
+    }
+    result.append(text.substr(last));
+    text = result;
+}
+
+PCRERegex::PCRERegex(const std::string &pattern, int flags)
+    : impl_(std::make_shared<Impl>(pattern, flags))
+{
+}
+
+PCRERegex::PCRERegex(const std::string &pattern)
+    : impl_(std::make_shared<Impl>(pattern, 0))
+{
+}
+
+PCRERegex::PCRERegex(PCRERegex && other)
+    : impl_(std::move(other.impl_))
+{
+}
+
+PCRERegex::~PCRERegex()
+{
+}
+
+
+std::vector<std::string> PCRERegex::get_all_matches(const std::string &text) const 
+{
+    return impl_->get_all_matches(text);
+}
+
+void PCRERegex::replace_all(std::string &text, const std::string &replacement) const
+{
+    impl_->replace_all(text, replacement);
+}
+
+bool PCRERegex::contains(const std::string& text) const {
+    return impl_->contains(text);
+}
+
+std::vector<std::pair<std::string::size_type, std::string::size_type>> PCRERegex::all_matches(const std::string &text) const
+{
+    return impl_->all_matches(text);
 }

--- a/pcre2_regex.h
+++ b/pcre2_regex.h
@@ -18,16 +18,12 @@
 #pragma once
 
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
-#define PCRE2_CODE_UNIT_WIDTH 0
-
-#include <pcre2.h>
-
 class PCRERegex {
-    pcre2_code_8 *regex_ = nullptr;
-
+    class Impl;
 public:
     PCRERegex(const std::string &pattern, int flags);
     explicit PCRERegex(const std::string &pattern);
@@ -39,4 +35,7 @@ public:
     void replace_all(std::string &text, const std::string &replacement) const;
     [[nodiscard]] bool contains(const std::string& text) const;
     [[nodiscard]] std::vector<std::pair<std::string::size_type, std::string::size_type>> all_matches(const std::string &text) const;
+
+private:
+    std::shared_ptr<Impl> impl_;
 };

--- a/ut/tests.cpp
+++ b/ut/tests.cpp
@@ -33,10 +33,18 @@ private:
 TEST(TestGetEncoding, TestDefaultEncod)
 {
     auto encoder = GptEncoding::get_encoding(LanguageModel::CL100K_BASE);
+    std::vector<int> tokens = encoder->encode("hello world");
+    ASSERT_EQ(tokens.size(), 2);
+    ASSERT_EQ(tokens[0], 15339);
+    ASSERT_EQ(tokens[1], 1917);
 }
 
 TEST(TestGetEncoding, TestCustomResourceReader)
 {
     TFilePathResourceReader reader("../tokenizers/cl100k_base.tiktoken");
     auto encoder = GptEncoding::get_encoding(LanguageModel::CL100K_BASE, &reader);
+    std::vector<int> tokens = encoder->encode("hello world");
+    ASSERT_EQ(tokens.size(), 2);
+    ASSERT_EQ(tokens[0], 15339);
+    ASSERT_EQ(tokens[1], 1917);
 }


### PR DESCRIPTION
User is not required to have pcre2 to use cpp_tiktoken (rm dependence from headers)